### PR TITLE
Change Role enum into Role Type && create mutation for new Project

### DIFF
--- a/database/datamodel.graphql
+++ b/database/datamodel.graphql
@@ -1,8 +1,7 @@
-enum Role {
-  MEMBER
-  TEAM_LEADER
-  GROUP_LEADER
-  ADMIN
+type Role {
+  id: ID! @unique
+  name: String! @unique
+  users: [User!]! @relation(name: "UserRoles", onDelete: SET_NULL)
 }
 
 type User {
@@ -13,14 +12,14 @@ type User {
   email: String! @unique
   avatar: String
   googleId: String @unique
-  roles: [Role!]!
+  roles: [Role!]! @relation(name: "UserRoles", onDelete: SET_NULL)
   completed: Boolean! @default(value: "false")
-  dailyReports: [DailyReport!]! @relation(name: "DailyReportsByUser" onDelete: CASCADE) # A user can has many daily reports.
-  weeklyReports: [WeeklyReport!]! @relation(name: "WeeklyReportsByUser" onDelete: CASCADE) # A user can has many weekly reports.
-  projects: [Project!]! @relation(name: "MembersProjects" onDelete: SET_NULL) # A user can belong to many different projects.
-  tasks: [Task!]! @relation(name: "MembersTasks" onDelete: SET_NULL) # A user can do many tasks in many projects.
-  membersActivities: [WeeklyReport!]! @relation(name: "MembersActivities" onDelete: CASCADE) # Reference to membersActivities in Weekly Report.
-  team: Team @relation(name: "UsersOfTeam" onDelete: SET_NULL) # A user belong to a team.
+  dailyReports: [DailyReport!]! @relation(name: "DailyReportsByUser", onDelete: CASCADE) # A user can has many daily reports.
+  weeklyReports: [WeeklyReport!]! @relation(name: "WeeklyReportsByUser", onDelete: CASCADE) # A user can has many weekly reports.
+  projects: [Project!]! @relation(name: "MembersProjects", onDelete: SET_NULL) # A user can belong to many different projects.
+  tasks: [Task!]! @relation(name: "MembersTasks", onDelete: SET_NULL) # A user can do many tasks in many projects.
+  membersActivities: [WeeklyReport!]! @relation(name: "MembersActivities", onDelete: CASCADE) # Reference to membersActivities in Weekly Report.
+  team: Team @relation(name: "UsersOfTeam", onDelete: SET_NULL) # A user belong to a team.
   createdAt: DateTime!
   updatedAt: DateTime!
 }
@@ -31,9 +30,9 @@ type Task {
   url: String!
   logtime: Int!
   description: String
-  members: [User!]! @relation(name: "MembersTasks" onDelete: SET_NULL) # A task can has many members.
-  attaches: [DailyReport!]! @relation(name: "TasksDailyReports" onDelete: SET_NULL) # A Task can be attached in many Daily Report.
-  project: Project @relation(name: "TasksProject" onDelete: SET_NULL) # A task belong a project.
+  members: [User!]! @relation(name: "MembersTasks", onDelete: SET_NULL) # A task can has many members.
+  attaches: [DailyReport!]! @relation(name: "TasksDailyReports", onDelete: SET_NULL) # A Task can be attached in many Daily Report.
+  project: Project @relation(name: "TasksProject", onDelete: SET_NULL) # A task belong a project.
   createdAt: DateTime!
   updatedAt: DateTime!
 }
@@ -42,10 +41,10 @@ type Project {
   id: ID! @unique
   title: String!
   description: String
-  members: [User!]! @relation(name: "MembersProjects" onDelete: CASCADE) # A project can has many members.
-  tasks: [Task!]! @relation(name: "TasksProject" onDelete: CASCADE) # A project can has many tasks.
-  attaches: [DailyReport!]! @relation(name: "ProjectsDailyReports" onDelete: SET_NULL) # A Project can be attached in many Daily Report.
-  teamLeader: User @relation(name: "TeamLeaderProject" onDelete: SET_NULL) # A project only has one team leader.
+  members: [User!]! @relation(name: "MembersProjects", onDelete: SET_NULL) # A project can has many members.
+  tasks: [Task!]! @relation(name: "TasksProject", onDelete: CASCADE) # A project can has many tasks.
+  attaches: [DailyReport!]! @relation(name: "ProjectsDailyReports", onDelete: SET_NULL) # A Project can be attached in many Daily Report.
+  teamLeader: User @relation(name: "TeamLeaderProject", onDelete: SET_NULL) # A project only has one team leader.
   createdAt: DateTime!
   updatedAt: DateTime!
 }
@@ -56,9 +55,9 @@ type DailyReport {
   title: String!
   plan: String!
   comment: String
-  projects: [Project!]! @relation(name: "ProjectsDailyReports" onDelete: SET_NULL) # All projects that member working on. (Ex: A member can work in many project)
-  tasks: [Task!]! @relation(name: "TasksDailyReports" onDelete: SET_NULL) # A tasks that member working on. (Ex: A member can work in many task on any project)
-  author: User! @relation(name: "DailyReportsByUser" onDelete: SET_NULL) # A daily report was created by the author (Member)
+  projects: [Project!]! @relation(name: "ProjectsDailyReports", onDelete: SET_NULL) # All projects that member working on. (Ex: A member can work in many project)
+  tasks: [Task!]! @relation(name: "TasksDailyReports", onDelete: SET_NULL) # A tasks that member working on. (Ex: A member can work in many task on any project)
+  author: User! @relation(name: "DailyReportsByUser", onDelete: SET_NULL) # A daily report was created by the author (Member)
   createdAt: DateTime!
   updatedAt: DateTime!
 }
@@ -69,8 +68,8 @@ type WeeklyReport {
   solution: String!
   description: String
   summary: String!
-  membersActivities: [User!]! @relation(name: "MembersActivities" onDelete: CASCADE) # Each member has their own activities.
-  author: User! @relation(name: "WeeklyReportsByUser" onDelete: SET_NULL) # A weekly report was created by the author (Team Leader)
+  membersActivities: [User!]! @relation(name: "MembersActivities", onDelete: SET_NULL) # Each member has their own activities.
+  author: User! @relation(name: "WeeklyReportsByUser", onDelete: SET_NULL) # A weekly report was created by the author (Team Leader)
   createdAt: DateTime!
   updatedAt: DateTime!
 }
@@ -88,7 +87,7 @@ type Group {
   id: ID! @unique
   name: String!
   description: String
-  teams: [Team!]! @relation(name: "TeamsOfGroup" onDelete: CASCADE) # A group can has many teams.
+  teams: [Team!]! @relation(name: "TeamsOfGroup", onDelete: CASCADE) # A group can has many teams.
   division: Division @relation(name: "DivisionGroup", onDelete: SET_NULL)
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -98,10 +97,8 @@ type Team {
   id: ID! @unique
   name: String!
   description: String
-  users: [User!]! @relation(name: "UsersOfTeam" onDelete: SET_NULL) # A team can has many users.
-  group: Group @relation(name: "TeamsOfGroup" onDelete: SET_NULL) # A team belong to a group.
+  users: [User!]! @relation(name: "UsersOfTeam", onDelete: SET_NULL) # A team can has many users.
+  group: Group @relation(name: "TeamsOfGroup", onDelete: SET_NULL) # A team belong to a group.
   createdAt: DateTime!
   updatedAt: DateTime!
 }
-
-

--- a/database/prisma.yml
+++ b/database/prisma.yml
@@ -9,8 +9,7 @@ datamodel: datamodel.graphql
 # `src/generated/prisma.graphql` (as specfied in `.graphqlconfig.yml`).
 hooks:
   post-deploy:
-  - graphql get-schema --project database
-
+    - graphql get-schema --project database
 # If specified, the `secret` must be used to generate a JWT which is attached
 # to the `Authorization` header of HTTP requests made against the Prisma API.
 # Info: https://www.prisma.io/docs/reference/prisma-api/concepts-utee3eiquo#authentication

--- a/src/generated/prisma.graphql
+++ b/src/generated/prisma.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:4466
-# timestamp: Wed Nov 21 2018 09:52:45 GMT+0700 (+07)
+# timestamp: Thu Nov 22 2018 08:24:13 GMT+0700 (+07)
 
 type AggregateDailyReport {
   count: Int!
@@ -14,6 +14,10 @@ type AggregateGroup {
 }
 
 type AggregateProject {
+  count: Int!
+}
+
+type AggregateRole {
   count: Int!
 }
 
@@ -196,13 +200,6 @@ input DailyReportUpdateInput {
   projects: ProjectUpdateManyWithoutAttachesInput
   tasks: TaskUpdateManyWithoutAttachesInput
   author: UserUpdateOneRequiredWithoutDailyReportsInput
-}
-
-input DailyReportUpdateManyMutationInput {
-  emotion: String
-  title: String
-  plan: String
-  comment: String
 }
 
 input DailyReportUpdateManyWithoutAuthorInput {
@@ -670,11 +667,6 @@ input DivisionUpdateInput {
   groups: GroupUpdateManyWithoutDivisionInput
 }
 
-input DivisionUpdateManyMutationInput {
-  name: String
-  description: String
-}
-
 input DivisionUpdateOneWithoutGroupsInput {
   create: DivisionCreateWithoutGroupsInput
   connect: DivisionWhereUniqueInput
@@ -1001,11 +993,6 @@ input GroupUpdateInput {
   division: DivisionUpdateOneWithoutGroupsInput
 }
 
-input GroupUpdateManyMutationInput {
-  name: String
-  description: String
-}
-
 input GroupUpdateManyWithoutDivisionInput {
   create: [GroupCreateWithoutDivisionInput!]
   connect: [GroupWhereUniqueInput!]
@@ -1235,6 +1222,9 @@ input GroupWhereUniqueInput {
   id: ID
 }
 
+"""Raw JSON value"""
+scalar Json
+
 """
 The `Long` scalar type represents non-fractional signed whole numeric values.
 Long can represent values between -(2^63) and 2^63 - 1.
@@ -1242,6 +1232,7 @@ Long can represent values between -(2^63) and 2^63 - 1.
 scalar Long
 
 type Mutation {
+  createRole(data: RoleCreateInput!): Role!
   createTask(data: TaskCreateInput!): Task!
   createProject(data: ProjectCreateInput!): Project!
   createDailyReport(data: DailyReportCreateInput!): DailyReport!
@@ -1250,6 +1241,7 @@ type Mutation {
   createGroup(data: GroupCreateInput!): Group!
   createTeam(data: TeamCreateInput!): Team!
   createUser(data: UserCreateInput!): User!
+  updateRole(data: RoleUpdateInput!, where: RoleWhereUniqueInput!): Role
   updateTask(data: TaskUpdateInput!, where: TaskWhereUniqueInput!): Task
   updateProject(data: ProjectUpdateInput!, where: ProjectWhereUniqueInput!): Project
   updateDailyReport(data: DailyReportUpdateInput!, where: DailyReportWhereUniqueInput!): DailyReport
@@ -1258,6 +1250,7 @@ type Mutation {
   updateGroup(data: GroupUpdateInput!, where: GroupWhereUniqueInput!): Group
   updateTeam(data: TeamUpdateInput!, where: TeamWhereUniqueInput!): Team
   updateUser(data: UserUpdateInput!, where: UserWhereUniqueInput!): User
+  deleteRole(where: RoleWhereUniqueInput!): Role
   deleteTask(where: TaskWhereUniqueInput!): Task
   deleteProject(where: ProjectWhereUniqueInput!): Project
   deleteDailyReport(where: DailyReportWhereUniqueInput!): DailyReport
@@ -1266,6 +1259,7 @@ type Mutation {
   deleteGroup(where: GroupWhereUniqueInput!): Group
   deleteTeam(where: TeamWhereUniqueInput!): Team
   deleteUser(where: UserWhereUniqueInput!): User
+  upsertRole(where: RoleWhereUniqueInput!, create: RoleCreateInput!, update: RoleUpdateInput!): Role!
   upsertTask(where: TaskWhereUniqueInput!, create: TaskCreateInput!, update: TaskUpdateInput!): Task!
   upsertProject(where: ProjectWhereUniqueInput!, create: ProjectCreateInput!, update: ProjectUpdateInput!): Project!
   upsertDailyReport(where: DailyReportWhereUniqueInput!, create: DailyReportCreateInput!, update: DailyReportUpdateInput!): DailyReport!
@@ -1274,14 +1268,16 @@ type Mutation {
   upsertGroup(where: GroupWhereUniqueInput!, create: GroupCreateInput!, update: GroupUpdateInput!): Group!
   upsertTeam(where: TeamWhereUniqueInput!, create: TeamCreateInput!, update: TeamUpdateInput!): Team!
   upsertUser(where: UserWhereUniqueInput!, create: UserCreateInput!, update: UserUpdateInput!): User!
-  updateManyTasks(data: TaskUpdateManyMutationInput!, where: TaskWhereInput): BatchPayload!
-  updateManyProjects(data: ProjectUpdateManyMutationInput!, where: ProjectWhereInput): BatchPayload!
-  updateManyDailyReports(data: DailyReportUpdateManyMutationInput!, where: DailyReportWhereInput): BatchPayload!
-  updateManyWeeklyReports(data: WeeklyReportUpdateManyMutationInput!, where: WeeklyReportWhereInput): BatchPayload!
-  updateManyDivisions(data: DivisionUpdateManyMutationInput!, where: DivisionWhereInput): BatchPayload!
-  updateManyGroups(data: GroupUpdateManyMutationInput!, where: GroupWhereInput): BatchPayload!
-  updateManyTeams(data: TeamUpdateManyMutationInput!, where: TeamWhereInput): BatchPayload!
-  updateManyUsers(data: UserUpdateManyMutationInput!, where: UserWhereInput): BatchPayload!
+  updateManyRoles(data: RoleUpdateInput!, where: RoleWhereInput): BatchPayload!
+  updateManyTasks(data: TaskUpdateInput!, where: TaskWhereInput): BatchPayload!
+  updateManyProjects(data: ProjectUpdateInput!, where: ProjectWhereInput): BatchPayload!
+  updateManyDailyReports(data: DailyReportUpdateInput!, where: DailyReportWhereInput): BatchPayload!
+  updateManyWeeklyReports(data: WeeklyReportUpdateInput!, where: WeeklyReportWhereInput): BatchPayload!
+  updateManyDivisions(data: DivisionUpdateInput!, where: DivisionWhereInput): BatchPayload!
+  updateManyGroups(data: GroupUpdateInput!, where: GroupWhereInput): BatchPayload!
+  updateManyTeams(data: TeamUpdateInput!, where: TeamWhereInput): BatchPayload!
+  updateManyUsers(data: UserUpdateInput!, where: UserWhereInput): BatchPayload!
+  deleteManyRoles(where: RoleWhereInput): BatchPayload!
   deleteManyTasks(where: TaskWhereInput): BatchPayload!
   deleteManyProjects(where: ProjectWhereInput): BatchPayload!
   deleteManyDailyReports(where: DailyReportWhereInput): BatchPayload!
@@ -1290,6 +1286,7 @@ type Mutation {
   deleteManyGroups(where: GroupWhereInput): BatchPayload!
   deleteManyTeams(where: TeamWhereInput): BatchPayload!
   deleteManyUsers(where: UserWhereInput): BatchPayload!
+  executeRaw(database: PrismaDatabase, query: String!): Json!
 }
 
 enum MutationType {
@@ -1317,6 +1314,10 @@ type PageInfo {
 
   """When paginating forwards, the cursor to continue."""
   endCursor: String
+}
+
+enum PrismaDatabase {
+  default
 }
 
 type Project implements Node {
@@ -1465,11 +1466,6 @@ input ProjectUpdateInput {
   tasks: TaskUpdateManyWithoutProjectInput
   attaches: DailyReportUpdateManyWithoutProjectsInput
   teamLeader: UserUpdateOneInput
-}
-
-input ProjectUpdateManyMutationInput {
-  title: String
-  description: String
 }
 
 input ProjectUpdateManyWithoutAttachesInput {
@@ -1740,6 +1736,7 @@ input ProjectWhereUniqueInput {
 }
 
 type Query {
+  roles(where: RoleWhereInput, orderBy: RoleOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Role]!
   tasks(where: TaskWhereInput, orderBy: TaskOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Task]!
   projects(where: ProjectWhereInput, orderBy: ProjectOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Project]!
   dailyReports(where: DailyReportWhereInput, orderBy: DailyReportOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [DailyReport]!
@@ -1748,6 +1745,7 @@ type Query {
   groups(where: GroupWhereInput, orderBy: GroupOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Group]!
   teams(where: TeamWhereInput, orderBy: TeamOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Team]!
   users(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User]!
+  role(where: RoleWhereUniqueInput!): Role
   task(where: TaskWhereUniqueInput!): Task
   project(where: ProjectWhereUniqueInput!): Project
   dailyReport(where: DailyReportWhereUniqueInput!): DailyReport
@@ -1756,6 +1754,7 @@ type Query {
   group(where: GroupWhereUniqueInput!): Group
   team(where: TeamWhereUniqueInput!): Team
   user(where: UserWhereUniqueInput!): User
+  rolesConnection(where: RoleWhereInput, orderBy: RoleOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): RoleConnection!
   tasksConnection(where: TaskWhereInput, orderBy: TaskOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): TaskConnection!
   projectsConnection(where: ProjectWhereInput, orderBy: ProjectOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): ProjectConnection!
   dailyReportsConnection(where: DailyReportWhereInput, orderBy: DailyReportOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): DailyReportConnection!
@@ -1772,14 +1771,230 @@ type Query {
   ): Node
 }
 
-enum Role {
-  MEMBER
-  TEAM_LEADER
-  GROUP_LEADER
-  ADMIN
+type Role implements Node {
+  id: ID!
+  name: String!
+  users(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
+}
+
+"""A connection to a list of items."""
+type RoleConnection {
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """A list of edges."""
+  edges: [RoleEdge]!
+  aggregate: AggregateRole!
+}
+
+input RoleCreateInput {
+  name: String!
+  users: UserCreateManyWithoutRolesInput
+}
+
+input RoleCreateManyWithoutUsersInput {
+  create: [RoleCreateWithoutUsersInput!]
+  connect: [RoleWhereUniqueInput!]
+}
+
+input RoleCreateWithoutUsersInput {
+  name: String!
+}
+
+"""An edge in a connection."""
+type RoleEdge {
+  """The item at the end of the edge."""
+  node: Role!
+
+  """A cursor for use in pagination."""
+  cursor: String!
+}
+
+enum RoleOrderByInput {
+  id_ASC
+  id_DESC
+  name_ASC
+  name_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+  createdAt_ASC
+  createdAt_DESC
+}
+
+type RolePreviousValues {
+  id: ID!
+  name: String!
+}
+
+type RoleSubscriptionPayload {
+  mutation: MutationType!
+  node: Role
+  updatedFields: [String!]
+  previousValues: RolePreviousValues
+}
+
+input RoleSubscriptionWhereInput {
+  """Logical AND on all given filters."""
+  AND: [RoleSubscriptionWhereInput!]
+
+  """Logical OR on all given filters."""
+  OR: [RoleSubscriptionWhereInput!]
+
+  """Logical NOT on all given filters combined by AND."""
+  NOT: [RoleSubscriptionWhereInput!]
+
+  """
+  The subscription event gets dispatched when it's listed in mutation_in
+  """
+  mutation_in: [MutationType!]
+
+  """
+  The subscription event gets only dispatched when one of the updated fields names is included in this list
+  """
+  updatedFields_contains: String
+
+  """
+  The subscription event gets only dispatched when all of the field names included in this list have been updated
+  """
+  updatedFields_contains_every: [String!]
+
+  """
+  The subscription event gets only dispatched when some of the field names included in this list have been updated
+  """
+  updatedFields_contains_some: [String!]
+  node: RoleWhereInput
+}
+
+input RoleUpdateInput {
+  name: String
+  users: UserUpdateManyWithoutRolesInput
+}
+
+input RoleUpdateManyWithoutUsersInput {
+  create: [RoleCreateWithoutUsersInput!]
+  connect: [RoleWhereUniqueInput!]
+  disconnect: [RoleWhereUniqueInput!]
+  delete: [RoleWhereUniqueInput!]
+  update: [RoleUpdateWithWhereUniqueWithoutUsersInput!]
+  upsert: [RoleUpsertWithWhereUniqueWithoutUsersInput!]
+}
+
+input RoleUpdateWithoutUsersDataInput {
+  name: String
+}
+
+input RoleUpdateWithWhereUniqueWithoutUsersInput {
+  where: RoleWhereUniqueInput!
+  data: RoleUpdateWithoutUsersDataInput!
+}
+
+input RoleUpsertWithWhereUniqueWithoutUsersInput {
+  where: RoleWhereUniqueInput!
+  update: RoleUpdateWithoutUsersDataInput!
+  create: RoleCreateWithoutUsersInput!
+}
+
+input RoleWhereInput {
+  """Logical AND on all given filters."""
+  AND: [RoleWhereInput!]
+
+  """Logical OR on all given filters."""
+  OR: [RoleWhereInput!]
+
+  """Logical NOT on all given filters combined by AND."""
+  NOT: [RoleWhereInput!]
+  id: ID
+
+  """All values that are not equal to given value."""
+  id_not: ID
+
+  """All values that are contained in given list."""
+  id_in: [ID!]
+
+  """All values that are not contained in given list."""
+  id_not_in: [ID!]
+
+  """All values less than the given value."""
+  id_lt: ID
+
+  """All values less than or equal the given value."""
+  id_lte: ID
+
+  """All values greater than the given value."""
+  id_gt: ID
+
+  """All values greater than or equal the given value."""
+  id_gte: ID
+
+  """All values containing the given string."""
+  id_contains: ID
+
+  """All values not containing the given string."""
+  id_not_contains: ID
+
+  """All values starting with the given string."""
+  id_starts_with: ID
+
+  """All values not starting with the given string."""
+  id_not_starts_with: ID
+
+  """All values ending with the given string."""
+  id_ends_with: ID
+
+  """All values not ending with the given string."""
+  id_not_ends_with: ID
+  name: String
+
+  """All values that are not equal to given value."""
+  name_not: String
+
+  """All values that are contained in given list."""
+  name_in: [String!]
+
+  """All values that are not contained in given list."""
+  name_not_in: [String!]
+
+  """All values less than the given value."""
+  name_lt: String
+
+  """All values less than or equal the given value."""
+  name_lte: String
+
+  """All values greater than the given value."""
+  name_gt: String
+
+  """All values greater than or equal the given value."""
+  name_gte: String
+
+  """All values containing the given string."""
+  name_contains: String
+
+  """All values not containing the given string."""
+  name_not_contains: String
+
+  """All values starting with the given string."""
+  name_starts_with: String
+
+  """All values not starting with the given string."""
+  name_not_starts_with: String
+
+  """All values ending with the given string."""
+  name_ends_with: String
+
+  """All values not ending with the given string."""
+  name_not_ends_with: String
+  users_every: UserWhereInput
+  users_some: UserWhereInput
+  users_none: UserWhereInput
+}
+
+input RoleWhereUniqueInput {
+  id: ID
+  name: String
 }
 
 type Subscription {
+  role(where: RoleSubscriptionWhereInput): RoleSubscriptionPayload
   task(where: TaskSubscriptionWhereInput): TaskSubscriptionPayload
   project(where: ProjectSubscriptionWhereInput): ProjectSubscriptionPayload
   dailyReport(where: DailyReportSubscriptionWhereInput): DailyReportSubscriptionPayload
@@ -1948,13 +2163,6 @@ input TaskUpdateInput {
   members: UserUpdateManyWithoutTasksInput
   attaches: DailyReportUpdateManyWithoutTasksInput
   project: ProjectUpdateOneWithoutTasksInput
-}
-
-input TaskUpdateManyMutationInput {
-  title: String
-  url: String
-  logtime: Int
-  description: String
 }
 
 input TaskUpdateManyWithoutAttachesInput {
@@ -2417,11 +2625,6 @@ input TeamUpdateInput {
   group: GroupUpdateOneWithoutTeamsInput
 }
 
-input TeamUpdateManyMutationInput {
-  name: String
-  description: String
-}
-
 input TeamUpdateManyWithoutGroupInput {
   create: [TeamCreateWithoutGroupInput!]
   connect: [TeamWhereUniqueInput!]
@@ -2659,7 +2862,7 @@ type User implements Node {
   email: String!
   avatar: String
   googleId: String
-  roles: [Role!]!
+  roles(where: RoleWhereInput, orderBy: RoleOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Role!]
   completed: Boolean!
   dailyReports(where: DailyReportWhereInput, orderBy: DailyReportOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [DailyReport!]
   weeklyReports(where: WeeklyReportWhereInput, orderBy: WeeklyReportOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [WeeklyReport!]
@@ -2689,7 +2892,7 @@ input UserCreateInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserCreaterolesInput
+  roles: RoleCreateManyWithoutUsersInput
   dailyReports: DailyReportCreateManyWithoutAuthorInput
   weeklyReports: WeeklyReportCreateManyWithoutAuthorInput
   projects: ProjectCreateManyWithoutMembersInput
@@ -2705,6 +2908,11 @@ input UserCreateManyWithoutMembersActivitiesInput {
 
 input UserCreateManyWithoutProjectsInput {
   create: [UserCreateWithoutProjectsInput!]
+  connect: [UserWhereUniqueInput!]
+}
+
+input UserCreateManyWithoutRolesInput {
+  create: [UserCreateWithoutRolesInput!]
   connect: [UserWhereUniqueInput!]
 }
 
@@ -2733,10 +2941,6 @@ input UserCreateOneWithoutWeeklyReportsInput {
   connect: UserWhereUniqueInput
 }
 
-input UserCreaterolesInput {
-  set: [Role!]
-}
-
 input UserCreateWithoutDailyReportsInput {
   name: String!
   address: String
@@ -2745,7 +2949,7 @@ input UserCreateWithoutDailyReportsInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserCreaterolesInput
+  roles: RoleCreateManyWithoutUsersInput
   weeklyReports: WeeklyReportCreateManyWithoutAuthorInput
   projects: ProjectCreateManyWithoutMembersInput
   tasks: TaskCreateManyWithoutMembersInput
@@ -2761,7 +2965,7 @@ input UserCreateWithoutMembersActivitiesInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserCreaterolesInput
+  roles: RoleCreateManyWithoutUsersInput
   dailyReports: DailyReportCreateManyWithoutAuthorInput
   weeklyReports: WeeklyReportCreateManyWithoutAuthorInput
   projects: ProjectCreateManyWithoutMembersInput
@@ -2777,9 +2981,25 @@ input UserCreateWithoutProjectsInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserCreaterolesInput
+  roles: RoleCreateManyWithoutUsersInput
   dailyReports: DailyReportCreateManyWithoutAuthorInput
   weeklyReports: WeeklyReportCreateManyWithoutAuthorInput
+  tasks: TaskCreateManyWithoutMembersInput
+  membersActivities: WeeklyReportCreateManyWithoutMembersActivitiesInput
+  team: TeamCreateOneWithoutUsersInput
+}
+
+input UserCreateWithoutRolesInput {
+  name: String!
+  address: String
+  phone: String
+  email: String!
+  avatar: String
+  googleId: String
+  completed: Boolean
+  dailyReports: DailyReportCreateManyWithoutAuthorInput
+  weeklyReports: WeeklyReportCreateManyWithoutAuthorInput
+  projects: ProjectCreateManyWithoutMembersInput
   tasks: TaskCreateManyWithoutMembersInput
   membersActivities: WeeklyReportCreateManyWithoutMembersActivitiesInput
   team: TeamCreateOneWithoutUsersInput
@@ -2793,7 +3013,7 @@ input UserCreateWithoutTasksInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserCreaterolesInput
+  roles: RoleCreateManyWithoutUsersInput
   dailyReports: DailyReportCreateManyWithoutAuthorInput
   weeklyReports: WeeklyReportCreateManyWithoutAuthorInput
   projects: ProjectCreateManyWithoutMembersInput
@@ -2809,7 +3029,7 @@ input UserCreateWithoutTeamInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserCreaterolesInput
+  roles: RoleCreateManyWithoutUsersInput
   dailyReports: DailyReportCreateManyWithoutAuthorInput
   weeklyReports: WeeklyReportCreateManyWithoutAuthorInput
   projects: ProjectCreateManyWithoutMembersInput
@@ -2825,7 +3045,7 @@ input UserCreateWithoutWeeklyReportsInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserCreaterolesInput
+  roles: RoleCreateManyWithoutUsersInput
   dailyReports: DailyReportCreateManyWithoutAuthorInput
   projects: ProjectCreateManyWithoutMembersInput
   tasks: TaskCreateManyWithoutMembersInput
@@ -2873,7 +3093,6 @@ type UserPreviousValues {
   email: String!
   avatar: String
   googleId: String
-  roles: [Role!]!
   completed: Boolean!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -2926,7 +3145,7 @@ input UserUpdateDataInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserUpdaterolesInput
+  roles: RoleUpdateManyWithoutUsersInput
   dailyReports: DailyReportUpdateManyWithoutAuthorInput
   weeklyReports: WeeklyReportUpdateManyWithoutAuthorInput
   projects: ProjectUpdateManyWithoutMembersInput
@@ -2943,24 +3162,13 @@ input UserUpdateInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserUpdaterolesInput
+  roles: RoleUpdateManyWithoutUsersInput
   dailyReports: DailyReportUpdateManyWithoutAuthorInput
   weeklyReports: WeeklyReportUpdateManyWithoutAuthorInput
   projects: ProjectUpdateManyWithoutMembersInput
   tasks: TaskUpdateManyWithoutMembersInput
   membersActivities: WeeklyReportUpdateManyWithoutMembersActivitiesInput
   team: TeamUpdateOneWithoutUsersInput
-}
-
-input UserUpdateManyMutationInput {
-  name: String
-  address: String
-  phone: String
-  email: String
-  avatar: String
-  googleId: String
-  completed: Boolean
-  roles: UserUpdaterolesInput
 }
 
 input UserUpdateManyWithoutMembersActivitiesInput {
@@ -2979,6 +3187,15 @@ input UserUpdateManyWithoutProjectsInput {
   delete: [UserWhereUniqueInput!]
   update: [UserUpdateWithWhereUniqueWithoutProjectsInput!]
   upsert: [UserUpsertWithWhereUniqueWithoutProjectsInput!]
+}
+
+input UserUpdateManyWithoutRolesInput {
+  create: [UserCreateWithoutRolesInput!]
+  connect: [UserWhereUniqueInput!]
+  disconnect: [UserWhereUniqueInput!]
+  delete: [UserWhereUniqueInput!]
+  update: [UserUpdateWithWhereUniqueWithoutRolesInput!]
+  upsert: [UserUpsertWithWhereUniqueWithoutRolesInput!]
 }
 
 input UserUpdateManyWithoutTasksInput {
@@ -3022,10 +3239,6 @@ input UserUpdateOneRequiredWithoutWeeklyReportsInput {
   upsert: UserUpsertWithoutWeeklyReportsInput
 }
 
-input UserUpdaterolesInput {
-  set: [Role!]
-}
-
 input UserUpdateWithoutDailyReportsDataInput {
   name: String
   address: String
@@ -3034,7 +3247,7 @@ input UserUpdateWithoutDailyReportsDataInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserUpdaterolesInput
+  roles: RoleUpdateManyWithoutUsersInput
   weeklyReports: WeeklyReportUpdateManyWithoutAuthorInput
   projects: ProjectUpdateManyWithoutMembersInput
   tasks: TaskUpdateManyWithoutMembersInput
@@ -3050,7 +3263,7 @@ input UserUpdateWithoutMembersActivitiesDataInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserUpdaterolesInput
+  roles: RoleUpdateManyWithoutUsersInput
   dailyReports: DailyReportUpdateManyWithoutAuthorInput
   weeklyReports: WeeklyReportUpdateManyWithoutAuthorInput
   projects: ProjectUpdateManyWithoutMembersInput
@@ -3066,9 +3279,25 @@ input UserUpdateWithoutProjectsDataInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserUpdaterolesInput
+  roles: RoleUpdateManyWithoutUsersInput
   dailyReports: DailyReportUpdateManyWithoutAuthorInput
   weeklyReports: WeeklyReportUpdateManyWithoutAuthorInput
+  tasks: TaskUpdateManyWithoutMembersInput
+  membersActivities: WeeklyReportUpdateManyWithoutMembersActivitiesInput
+  team: TeamUpdateOneWithoutUsersInput
+}
+
+input UserUpdateWithoutRolesDataInput {
+  name: String
+  address: String
+  phone: String
+  email: String
+  avatar: String
+  googleId: String
+  completed: Boolean
+  dailyReports: DailyReportUpdateManyWithoutAuthorInput
+  weeklyReports: WeeklyReportUpdateManyWithoutAuthorInput
+  projects: ProjectUpdateManyWithoutMembersInput
   tasks: TaskUpdateManyWithoutMembersInput
   membersActivities: WeeklyReportUpdateManyWithoutMembersActivitiesInput
   team: TeamUpdateOneWithoutUsersInput
@@ -3082,7 +3311,7 @@ input UserUpdateWithoutTasksDataInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserUpdaterolesInput
+  roles: RoleUpdateManyWithoutUsersInput
   dailyReports: DailyReportUpdateManyWithoutAuthorInput
   weeklyReports: WeeklyReportUpdateManyWithoutAuthorInput
   projects: ProjectUpdateManyWithoutMembersInput
@@ -3098,7 +3327,7 @@ input UserUpdateWithoutTeamDataInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserUpdaterolesInput
+  roles: RoleUpdateManyWithoutUsersInput
   dailyReports: DailyReportUpdateManyWithoutAuthorInput
   weeklyReports: WeeklyReportUpdateManyWithoutAuthorInput
   projects: ProjectUpdateManyWithoutMembersInput
@@ -3114,7 +3343,7 @@ input UserUpdateWithoutWeeklyReportsDataInput {
   avatar: String
   googleId: String
   completed: Boolean
-  roles: UserUpdaterolesInput
+  roles: RoleUpdateManyWithoutUsersInput
   dailyReports: DailyReportUpdateManyWithoutAuthorInput
   projects: ProjectUpdateManyWithoutMembersInput
   tasks: TaskUpdateManyWithoutMembersInput
@@ -3130,6 +3359,11 @@ input UserUpdateWithWhereUniqueWithoutMembersActivitiesInput {
 input UserUpdateWithWhereUniqueWithoutProjectsInput {
   where: UserWhereUniqueInput!
   data: UserUpdateWithoutProjectsDataInput!
+}
+
+input UserUpdateWithWhereUniqueWithoutRolesInput {
+  where: UserWhereUniqueInput!
+  data: UserUpdateWithoutRolesDataInput!
 }
 
 input UserUpdateWithWhereUniqueWithoutTasksInput {
@@ -3167,6 +3401,12 @@ input UserUpsertWithWhereUniqueWithoutProjectsInput {
   where: UserWhereUniqueInput!
   update: UserUpdateWithoutProjectsDataInput!
   create: UserCreateWithoutProjectsInput!
+}
+
+input UserUpsertWithWhereUniqueWithoutRolesInput {
+  where: UserWhereUniqueInput!
+  update: UserUpdateWithoutRolesDataInput!
+  create: UserCreateWithoutRolesInput!
 }
 
 input UserUpsertWithWhereUniqueWithoutTasksInput {
@@ -3518,6 +3758,9 @@ input UserWhereInput {
 
   """All values greater than or equal the given value."""
   updatedAt_gte: DateTime
+  roles_every: RoleWhereInput
+  roles_some: RoleWhereInput
+  roles_none: RoleWhereInput
   dailyReports_every: DailyReportWhereInput
   dailyReports_some: DailyReportWhereInput
   dailyReports_none: DailyReportWhereInput
@@ -3681,13 +3924,6 @@ input WeeklyReportUpdateInput {
   summary: String
   membersActivities: UserUpdateManyWithoutMembersActivitiesInput
   author: UserUpdateOneRequiredWithoutWeeklyReportsInput
-}
-
-input WeeklyReportUpdateManyMutationInput {
-  issue: String
-  solution: String
-  description: String
-  summary: String
 }
 
 input WeeklyReportUpdateManyWithoutAuthorInput {

--- a/src/index.js
+++ b/src/index.js
@@ -21,11 +21,20 @@ server.express.use((req, res, next) => {
 // Populates the user cookie on each request
 server.express.use(async (req, res, next) => {
   if (!req.userId) return next();
-  const user = await db.query.user(
-    { where: { id: req.userId } },
-    `{ id, roles, email, name }`
+  const user = await db.query.user({ where: { id: req.userId } }, `{ id, email, name }`);
+  const roles = await db.query.roles(
+    {
+      where: {
+        users_some: {
+          id: user.id
+        }
+      }
+    },
+    `{ name }`
   );
   req.user = user;
+  req.roles = roles;
+
   next();
 });
 
@@ -34,7 +43,7 @@ server.start(
     cors: {
       credentials: true,
       origin: process.env.FRONT_END_URL
-    },
+    }
   },
   () => console.log(`Server is running on http://localhost:${process.env.PORT}`)
 );

--- a/src/resolvers/Mutation/auth.js
+++ b/src/resolvers/Mutation/auth.js
@@ -13,13 +13,14 @@ const createPrismaUser = async (ctx, googleUser) => {
       googleId: googleUser.id,
       email: googleUser.email,
       avatar: googleUser.picture,
-      roles: { set: ['MEMBER'] }
+      roles: {
+        connect: { name: 'MEMBER' }
+      }
     }
   });
 };
 
 const auth = {
-
   authenticate: async (parent, args, ctx, info) => {
     const { googleCode } = args;
     const googleToken = await google.getGoogleToken(googleCode);
@@ -35,7 +36,7 @@ const auth = {
 
     ctx.response.cookie('token', token, {
       httpOnly: true,
-      maxAge: 1000 * 60 * 60 * 24 * 365,
+      maxAge: 1000 * 60 * 60 * 24 * 365
     });
 
     return {
@@ -45,7 +46,7 @@ const auth = {
 
   signout: (parent, args, ctx, info) => {
     ctx.response.clearCookie('token');
-    return { message: 'Goodbye!'};
+    return { message: 'Goodbye!' };
   },
 
   editProfile: (parent, args, ctx, info) => {
@@ -53,7 +54,7 @@ const auth = {
 
     if (!userId) throw new Error('You are not logged in');
 
-    const updates = {...args};
+    const updates = { ...args };
 
     delete updates.id;
 
@@ -64,9 +65,7 @@ const auth = {
       },
       info
     );
-
-  },
-
+  }
 };
 
 module.exports = { auth };

--- a/src/resolvers/Mutation/dailyReport.js
+++ b/src/resolvers/Mutation/dailyReport.js
@@ -1,17 +1,15 @@
 const { getUserId } = require('../../utils');
 
 const dailyReport = {
-
   createDailyReport: async (parent, args, ctx, info) => {
     const userId = getUserId(ctx);
 
     const taskArgs = args.tasks.map(task => ({
-        url: task.url,
-        logtime: task.logtime,
-        project: { connect: { id: task.projectId } },
-        members: { connect: [ { id: userId } ] }
-      })
-    );
+      url: task.url,
+      logtime: task.logtime,
+      project: { connect: { id: task.projectId } },
+      members: { connect: [{ id: userId }] }
+    }));
 
     return ctx.db.mutation.createDailyReport(
       {
@@ -23,11 +21,10 @@ const dailyReport = {
           tasks: {
             create: taskArgs
           }
-        },
+        }
       },
       info
     );
-
   },
 
   updateDailyReport: async (parent, args, ctx, info) => {
@@ -35,21 +32,23 @@ const dailyReport = {
 
     const reportExists = await ctx.db.exists.DailyReport({
       id: args.id,
-      author: { id: userId },
+      author: { id: userId }
     });
 
     if (!reportExists) {
       throw new Error('Daily Report not found or you are not the author');
     }
 
-    const dailyReport = await ctx.db.query.dailyReport({
-      where: { id: args.id }
-    }, `{ id tasks { id } }`);
+    const dailyReport = await ctx.db.query.dailyReport(
+      {
+        where: { id: args.id }
+      },
+      `{ id tasks { id } }`
+    );
 
     // Update 1: Delete all of tasks in dailyReport.
     // Check if daily Report don't have any tasks, skip this step.
     if (dailyReport.tasks.length > 0) {
-
       const updates1 = {
         ...args,
         tasks: {
@@ -71,13 +70,12 @@ const dailyReport = {
     // Update 2: Create new tasks
     // Get all tasks from client.
     const taskArgs = args.tasks.map(task => ({
-        url: task.url,
-        logtime: task.logtime,
+      url: task.url,
+      logtime: task.logtime,
 
-        // connect to exists project
-        project: { connect: { id: task.projectId } }
-      })
-    );
+      // connect to exists project
+      project: { connect: { id: task.projectId } }
+    }));
 
     const updates2 = {
       ...args,
@@ -101,7 +99,7 @@ const dailyReport = {
     const userId = getUserId(ctx);
     const reportExists = await ctx.db.exists.DailyReport({
       id,
-      author: { id: userId },
+      author: { id: userId }
     });
 
     if (!reportExists) {
@@ -110,13 +108,11 @@ const dailyReport = {
 
     return ctx.db.mutation.deleteDailyReport(
       {
-        where: { id },
+        where: { id }
       },
       info
     );
-  },
-
+  }
 };
 
 module.exports = { dailyReport };
-

--- a/src/resolvers/Mutation/division.js
+++ b/src/resolvers/Mutation/division.js
@@ -1,28 +1,22 @@
-const { getUserId } = require('../../utils');
+const { getUserId, checkPermission } = require('../../utils');
+const permittedRoles = ['ADMIN'];
 
 const division = {
-
   createDivision: async (parent, args, ctx, info) => {
     // Check if user logged in
     const userId = getUserId(ctx);
 
     // Check if user has permission to do this
-    const hasPermissions = ctx.request.user.roles.some(role =>
-      ['ADMIN'].includes(role)
-    );
-
-    if (!hasPermissions) {
-      throw new Error("You don't have permission to do that!")
-    }
+    checkPermission(ctx.request.roles, permittedRoles);
 
     const { name, description } = args;
 
     return ctx.db.mutation.createDivision(
       {
-        data: { name, description },
+        data: { name, description }
       },
       info
-    )
+    );
   },
 
   updateDivision: async (parent, args, ctx, info) => {
@@ -30,13 +24,7 @@ const division = {
     const userId = getUserId(ctx);
 
     // Check if user has permission to do this
-    const hasPermissions = ctx.request.user.roles.some(role =>
-      ['ADMIN'].includes(role)
-    );
-
-    if (!hasPermissions) {
-      throw new Error("You don't have permission to do that!")
-    }
+    checkPermission(ctx.request.roles, permittedRoles);
 
     // Check if division exists
     const divisionExists = await ctx.db.exists.Division({
@@ -54,7 +42,7 @@ const division = {
         data: updates
       },
       info
-    )
+    );
   },
 
   deleteDivision: async (parent, { id }, ctx, info) => {
@@ -62,13 +50,7 @@ const division = {
     const userId = getUserId(ctx);
 
     // Check if user has permission to do this
-    const hasPermissions = ctx.request.user.roles.some(role =>
-      ['ADMIN'].includes(role)
-    );
-
-    if (!hasPermissions) {
-      throw new Error("You don't have permission to do that!")
-    }
+    checkPermission(ctx.request.roles, permittedRoles);
 
     // Check if division exists
     const divisionExists = await ctx.db.exists.Division({
@@ -79,13 +61,11 @@ const division = {
 
     return ctx.db.mutation.deleteDivision(
       {
-        where: { id },
+        where: { id }
       },
       info
-    )
-  },
-
+    );
+  }
 };
 
 module.exports = { division };
-

--- a/src/resolvers/Mutation/project.js
+++ b/src/resolvers/Mutation/project.js
@@ -1,0 +1,29 @@
+const { checkPermission } = require('../../utils');
+const permittedRoles = ['ADMIN', 'GROUP_LEADER'];
+
+const project = {
+  createProject: (parent, args, ctx, info) => {
+    checkPermission(ctx.request.roles, permittedRoles);
+
+    const membersId = args.members.map(id => ({
+      id
+    }));
+
+    return ctx.db.mutation.createProject(
+      {
+        data: {
+          ...args,
+          teamLeader: {
+            connect: { id: args.teamLeader }
+          },
+          members: {
+            connect: membersId
+          }
+        }
+      },
+      info
+    );
+  }
+};
+
+module.exports = { project };

--- a/src/resolvers/Mutation/team.js
+++ b/src/resolvers/Mutation/team.js
@@ -1,28 +1,22 @@
 const { getUserId } = require('../../utils');
+const permittedRoles = ['ADMIN', 'GROUP_LEADER'];
 
 const team = {
-
   createTeam: async (parent, args, ctx, info) => {
     // Check if user logged in
     const userId = getUserId(ctx);
 
     // Check if user has permission to do this
-    const hasPermissions = ctx.request.user.roles.some(role =>
-      ['GROUP_LEADER', 'ADMIN'].includes(role)
-    );
-
-    if (!hasPermissions) {
-      throw new Error("You don't have permission to do that!")
-    }
+    checkPermission(ctx.request.roles, permittedRoles);
 
     const { name, description } = args;
 
     return ctx.db.mutation.createTeam(
       {
-        data: { name, description },
+        data: { name, description }
       },
       info
-    )
+    );
   },
 
   updateTeam: async (parent, args, ctx, info) => {
@@ -30,13 +24,7 @@ const team = {
     const userId = getUserId(ctx);
 
     // Check if user has permission to do this
-    const hasPermissions = ctx.request.user.roles.some(role =>
-      ['GROUP_LEADER', 'ADMIN'].includes(role)
-    );
-
-    if (!hasPermissions) {
-      throw new Error("You don't have permission to do that!")
-    }
+    checkPermission(ctx.request.roles, permittedRoles);
 
     // Check if team exists
     const teamExists = await ctx.db.exists.Team({
@@ -54,7 +42,7 @@ const team = {
         data: updates
       },
       info
-    )
+    );
   },
 
   deleteTeam: async (parent, { id }, ctx, info) => {
@@ -62,13 +50,7 @@ const team = {
     const userId = getUserId(ctx);
 
     // Check if user has permission to do this
-    const hasPermissions = ctx.request.user.roles.some(role =>
-      ['GROUP_LEADER', 'ADMIN'].includes(role)
-    );
-
-    if (!hasPermissions) {
-      throw new Error("You don't have permission to do that!")
-    }
+    checkPermission(ctx.request.roles, permittedRoles);
 
     // Check if team exists
     const teamExists = await ctx.db.exists.Team({
@@ -79,13 +61,11 @@ const team = {
 
     return ctx.db.mutation.deleteTeam(
       {
-        where: { id },
+        where: { id }
       },
       info
-    )
-  },
-
+    );
+  }
 };
 
 module.exports = { team };
-

--- a/src/resolvers/Mutation/weeklyReport.js
+++ b/src/resolvers/Mutation/weeklyReport.js
@@ -1,17 +1,11 @@
-const { getUserId } = require('../../utils');
+const { getUserId, checkPermission } = require('../../utils');
+const permittedRoles = ['ADMIN', 'TEAM_LEADER'];
 
 const weeklyReport = {
-
   createWeeklyReport: async (parent, args, ctx, info) => {
     const userId = getUserId(ctx);
 
-    const hasPermissions = ctx.request.user.roles.some(role =>
-      ['TEAM_LEADER'].includes(role)
-    );
-
-    if (!hasPermissions) {
-      throw new Error("You don't have permission to do that!")
-    }
+    checkPermission(ctx.request.roles, permittedRoles);
 
     return ctx.db.mutation.createWeeklyReport(
       {
@@ -20,13 +14,11 @@ const weeklyReport = {
           author: {
             connect: { id: userId }
           }
-        },
+        }
       },
       info
     );
-  },
-
+  }
 };
 
 module.exports = { weeklyReport };
-

--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -9,6 +9,8 @@ const Query = {
   users: forwardTo('db'),
   teams: forwardTo('db'),
   team: forwardTo('db'),
+  project: forwardTo('db'),
+  projects: forwardTo('db'),
 
   me: (parent, args, ctx, info) => {
     const id = getUserId(ctx);
@@ -56,8 +58,7 @@ const Query = {
       dailyReportIds: dailyReports.map(dailyReport => dailyReport.id),
       orderBy
     };
-  },
-
+  }
 };
 
 module.exports = { Query };

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -6,6 +6,7 @@ const { team } = require('./Mutation/team');
 const { auth } = require('./Mutation/auth');
 const { dailyReport } = require('./Mutation/dailyReport');
 const { weeklyReport } = require('./Mutation/weeklyReport');
+const { project } = require('./Mutation/project');
 const { AuthPayload } = require('./AuthPayload');
 const { DailyReportList } = require('./DailyReportList');
 
@@ -16,7 +17,8 @@ module.exports = {
     ...division,
     ...team,
     ...dailyReport,
-    ...weeklyReport
+    ...weeklyReport,
+    ...project
   },
   Subscription,
   AuthPayload,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -16,6 +16,10 @@ input TaskInput {
   logtime: String
 }
 
+input UserInput {
+  id: ID!
+}
+
 type Query {
   info: String!
 
@@ -49,7 +53,27 @@ type Query {
     last: Int
   ): DailyReportList
   me: User!
-  users(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]!
+  users(
+    where: UserWhereInput
+    orderBy: UserOrderByInput
+    skip: Int
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): [User!]!
+
+  # Project Query
+  project(where: ProjectWhereUniqueInput!): Project!
+  projects(
+    where: ProjectWhereInput
+    orderBy: ProjectOrderByInput
+    skip: Int
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): [Project!]!
 }
 
 type Mutation {
@@ -91,18 +115,15 @@ type Mutation {
     summary: String!
   ): WeeklyReport!
 
+  # Project CRUD
+  createProject(title: String!, members: [ID!], teamLeader: ID!): Project!
+
   #  Google Authentication
   authenticate(googleCode: String!): AuthPayload
   signout: SuccessMessage
 
   # Edit Profile
-  editProfile(
-    id: ID!
-    address: String
-    phone: String
-    email: String
-    avatar: String
-  ): User
+  editProfile(id: ID!, address: String, phone: String, email: String, avatar: String): User
 }
 
 type Subscription {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,14 @@ function getUserId(ctx) {
   throw new AuthError();
 }
 
+function checkPermission(requestRoles, permittedRoles) {
+  const hasPermissions = requestRoles.some(role => permittedRoles.includes(role.name));
+
+  if (!hasPermissions) {
+    throw new Error("You don't have permission to do that!");
+  }
+}
+
 class AuthError extends Error {
   constructor() {
     super('Not authorized');
@@ -14,5 +22,6 @@ class AuthError extends Error {
 
 module.exports = {
   getUserId,
+  checkPermission,
   AuthError
 };


### PR DESCRIPTION
## Story URL
https://trello.com/c/vZ32ZMYJ

## What I did
- Change `enum Role` into `type Role`
I did this because Prisma doesn't create any filter for `enum` value.

See this issue for more info
https://github.com/prisma/prisma/issues/1275

- Create a resolver for Project mutation
- Define `checkPermission` function in utils.js 

*If you want to try this code on your local machine,  check out to https://github.com/emily0604/reporting_system_client/pull/42 and set `PRISMA_ENDPOINT=https://us1.prisma.sh/yuji-matsumoto-fe3e43/debug-reporting-system/dev` in your server repo's `.env` file.


## 🚨Migration After this pull request is merged
Since this pull request contains `data model` changes, we need to follow the steps below after this pull request is merged!!

1. Run `$ Prisma deploy --force`
2. Create 4 `Roles` --- with Prisma console or GraphQL Playground with mutation below
```
// Repeat this for MEMBER, TEAM_LEADER, GROUP_LEADER, ADMIN
mutation {
  createRole(
  	data: {
      name: "MEMBER" 
    }
  ) {
    name
  }
}
```

3. Connect roles to your User account --- with Prisma console or GraphQL Playground with mutation below




```

mutation {
  updateUser(
    where: {
      id: "" // Type your user ID here
    }
    data: {
      roles: {
        connect: [
          {name: "ADMIN"},
          {name: "GROUP_LEADER"},
          {name: "MEMBER"},
          {name: "TEAM_LEADER"}
        ],
      }
    }
  ) {
    name 
    roles {
      id
      name
    }
  }
}

```  